### PR TITLE
Removed preview URL simplification

### DIFF
--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -10,17 +10,3 @@
     '@controller': 'Redirect'
     '@action': 'redirect'
   httpMethods: ['GET','POST']
-
-##
-# Simplified monocle route ("/preview" instead of "/monocle/preview/module")
-
--
-  name:  'Monocle Preview - Module'
-  uriPattern: 'preview'
-  defaults:
-    '@package': 'Sitegeist.Monocle'
-    '@subpackage': ''
-    '@action': 'index'
-    '@controller': 'Module'
-    '@format': 'html'
-  httpMethods: ['GET','POST']

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Just require this package and you get:
 - Styleguides from your neos-packages rendered (else you get an exception about a
   missing site)
 - A routing from "/" to the monocle preview backend
-- Simplified routes to monocle endpoints (/preview/ instead of /preview/monocle/module)
 
 Some pieces of this might be obsoleted in later versions of Monocle. See:
 - https://github.com/sitegeist/Sitegeist.Monocle/issues/115


### PR DESCRIPTION
This does not work as expected. Use default monocle delivered routes as is.