### PR TITLE
Update sitegeist/monocle requirement to ^7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "neos-site",
   "license": "MIT",
   "require": {
-    "sitegeist/monocle": "^6.2"
+    "sitegeist/monocle": "^7.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The sitegeist/monocle version ^6.2 is not compatible to the updated versions of Neos/Flow and Neos/Fusion.